### PR TITLE
Add missing publishing of installers when taggging a release

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -7,6 +7,8 @@ on:
   push:
     branches: [ master, main]
     tags: [ "*" ]
+  release:
+    types: [ published ]
 
 env:
   pkg-assembly: 'krystal-bull-assembly-0.1.jar'


### PR DESCRIPTION
Now when we add a new tag, this will build installers for krystal bull