### PR TITLE
Change sys.exit() to Platform.exit()

### DIFF
--- a/src/main/scala/com/krystal/bull/gui/AppMenuBar.scala
+++ b/src/main/scala/com/krystal/bull/gui/AppMenuBar.scala
@@ -4,6 +4,7 @@ import com.krystal.bull.gui.settings.Themes
 import org.bitcoins.commons.jsonmodels.ExplorerEnv
 import scalafx.scene.control._
 import scalafx.scene.input.{KeyCode, KeyCodeCombination, KeyCombination}
+import scalafx.application.Platform
 
 import java.nio.file.Path
 
@@ -24,7 +25,7 @@ private class FileMenu() {
     mnemonicParsing = true
     accelerator =
       new KeyCodeCombination(KeyCode.Q, KeyCombination.ControlDown) // CTRL + Q
-    onAction = _ => sys.exit()
+    onAction = _ => Platform.exit()
   }
 
   val fileMenu: Menu =


### PR DESCRIPTION
Hello, this is my first OSS pull request so please feel free to let me know if anything is done incorrectly

According to issue #83, Krystal Bull does not quit on Mac OS when using the "Quit" menu item:
https://github.com/bitcoin-s/krystal-bull/issues/83

I imported (1) scalafx.application.Platform and (2) changed sys.exit() to Platform.exit(), which seems to have solved the problem

According to the Oracle documentation, Platform.exit() is the preferred way to explicitly terminate an application:
https://docs.oracle.com/javase/8/javafx/api/javafx/application/Application.html